### PR TITLE
mido: fingerprint: keep in system-background

### DIFF
--- a/biometrics/android.hardware.biometrics.fingerprint@2.1-service.xiaomi_mido.rc
+++ b/biometrics/android.hardware.biometrics.fingerprint@2.1-service.xiaomi_mido.rc
@@ -5,4 +5,5 @@ service fps_hal /vendor/bin/hw/android.hardware.biometrics.fingerprint@2.1-servi
     class late_start
     user system
     group system input
+    writepid /dev/cpuset/system-background/tasks
     disabled


### PR DESCRIPTION
The fingerprint HAL is insensitive to increased CPU throughput, but it also
has a tendency to spin while waiting for FP hardware. Limit FPC to the
system-background cpuset in order to avoid increased power consumption
when accidentally touching the fingerprint sensor.

Basically,It is a slow interaction in IRQ wake on the Pie fingerprint HAL.
This commit seems to work and somehow solves the slow fp wake issue, not completely tho. Already tested on my own feel free to review it.
 
Change-Id: Iaffe6f63bd76b7a1c4acaf0cae980840af515961
Signed-off-by: Dede Dindin Qudsy <xtrymind@gmail.com>